### PR TITLE
fix(ui): restore prepend spacing and add navigation subheader in processing actions

### DIFF
--- a/api/types/processing/schema.js
+++ b/api/types/processing/schema.js
@@ -77,7 +77,7 @@ export default {
     debug: {
       type: 'boolean',
       title: 'Mode debug',
-      description: 'Active le mode debug pour ce traitement',
+      description: 'Capture des logs détaillés (stacks d\'erreurs, appels HTTP) réservés aux super-admins, pour diagnostiquer un plugin en erreur.',
       readOnly: true
     },
     owner: {

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
     <style>@layer vuetify-core, vuetify-components, vuetify-overrides, vuetify-utilities, vuetify-final;</style>
     <link href="{SITE_PATH}/simple-directory/api/sites/{THEME_CSS_HASH}_theme.css" rel="stylesheet">
   </head>

--- a/ui/src/components/processing/processing-actions.vue
+++ b/ui/src/components/processing/processing-actions.vue
@@ -1,4 +1,33 @@
 <template>
+  <!-- Navigation -->
+  <template v-if="linkedDatasets.length">
+    <v-list-subheader class="text-uppercase">
+      {{ t('navigation') }}
+    </v-list-subheader>
+    <v-list-item
+      v-for="d in linkedDatasets"
+      :key="d.id"
+      :href="`/data-fair/dataset/${d.id}`"
+      target="_blank"
+      rounded
+    >
+      <template #prepend>
+        <v-icon
+          color="primary"
+          :icon="mdiOpenInNew"
+        />
+      </template>
+      {{ t('viewDataset', { title: d.title }) }}
+    </v-list-item>
+  </template>
+
+  <v-list-subheader
+    v-if="hasActions"
+    class="text-uppercase"
+  >
+    {{ t('actions') }}
+  </v-list-subheader>
+
   <!-- Execute -->
   <v-menu
     v-if="canAdmin || canExec"
@@ -230,22 +259,6 @@
     </v-card>
   </v-menu>
 
-  <!-- Dataset link -->
-  <v-list-item
-    v-if="processing?.config?.dataset?.id"
-    :href="`/data-fair/dataset/${processing.config.dataset.id}`"
-    target="_blank"
-    rounded
-  >
-    <template #prepend>
-      <v-icon
-        color="primary"
-        :icon="mdiOpenInNew"
-      />
-    </template>
-    {{ t('viewDataset') }}
-  </v-list-item>
-
   <!-- Documentation link -->
   <v-list-item
     v-if="metadata?.documentation"
@@ -342,6 +355,32 @@ const newOwner = ref<Account>(session.state.account)
 const duplicateTitle = ref(`${processing.title} ${t('copy')}`)
 
 const canSubscribeNotif = computed(() => processing?.owner.type === session.state.account.type && processing?.owner.id === session.state.account.id)
+
+const linkedDatasets = computed(() => {
+  const seen = new Set<string>()
+  const result: { id: string, title: string }[] = []
+  const add = (d: any) => {
+    if (!d?.id || seen.has(d.id)) return
+    seen.add(d.id)
+    result.push({ id: d.id, title: d.title || d.id })
+  }
+  const cfg = processing?.config
+  if (!cfg) return result
+  add(cfg.dataset)
+  if (Array.isArray(cfg.datasets)) {
+    for (const entry of cfg.datasets) {
+      add(entry?.dataset ?? entry)
+    }
+  }
+  return result
+})
+
+const hasActions = computed(() =>
+  canAdmin || canExec ||
+  !!metadata?.documentation ||
+  !!session.state.user?.adminMode ||
+  (!!eventsSubscribeUrl.value && canSubscribeNotif.value)
+)
 const ownerString = computed(() => `${processing?.owner.type}:${processing?.owner.id}${processing?.owner.department ? ':' + processing?.owner.department : ''}`)
 
 const eventsSubscribeUrl = computed(() => {
@@ -461,7 +500,9 @@ en:
   sensitiveOperation: Sensitive operation
   changeOwnerWarning: Changing the owner of a processing can have consequences on the processing execution.
   confirm: Confirm
-  viewDataset: View the dataset
+  navigation: Navigation
+  actions: Actions
+  viewDataset: "View {title}"
   tutorial: Tutorial
   useApi: Use the API
   notifications: Notifications
@@ -497,7 +538,9 @@ fr:
   sensitiveOperation: Opération sensible
   changeOwnerWarning: Changer le propriétaire d'un traitement peut avoir des conséquences sur l'execution du traitement.
   confirm: Confirmer
-  viewDataset: Voir le jeu de données
+  navigation: Navigation
+  actions: Actions
+  viewDataset: "Voir {title}"
   tutorial: Tutoriel
   useApi: Utiliser l'API
   notifications: Notifications

--- a/ui/src/components/processing/processing-activity.vue
+++ b/ui/src/components/processing/processing-activity.vue
@@ -2,6 +2,7 @@
   <v-list-item
     :prepend-avatar="avatarUrl"
     :title="ownerName"
+    prepend-gap="20"
   />
   <v-list-item
     v-if="processing.updated"

--- a/ui/src/components/processing/processing-card.vue
+++ b/ui/src/components/processing/processing-card.vue
@@ -70,13 +70,15 @@
 
         <!-- Last run -->
         <template v-if="processing.lastRun">
-          <v-list-item v-if="processing.lastRun.status === 'running'">
+          <v-list-item
+            v-if="processing.lastRun.status === 'running'"
+            prepend-gap="28"
+          >
             <template #prepend>
               <v-progress-circular
                 indeterminate
                 color="primary"
                 size="small"
-                class="mr-7"
               />
             </template>
             {{ t('runStarted') }} {{ dayjs(processing.lastRun.startedAt).fromNow() }}

--- a/ui/src/components/run/run-list-item.vue
+++ b/ui/src/components/run/run-list-item.vue
@@ -1,6 +1,7 @@
 <template>
   <v-list-item
     class="py-4"
+    prepend-gap="32"
     :to="link ? `/processings/${run.processing._id}/runs/${run._id}` : ''"
   >
     <template #prepend>


### PR DESCRIPTION
- Set explicit `prepend-gap` on affected `v-list-item`s to restore the horizontal gap between the prepended element and the title/text. Vuetify 4 only applies the spacer default width when the prepend direct child is a `v-icon`, `v-badge`, `v-tooltip` or `v-avatar` — a wrapped avatar or a `v-progress-circular` falls through to `var(--v-list-prepend-gap)` with no fallback and collapses to 0 (runs list item, processing card "running" row, owner avatar in the activity block).
- Rewrite the `debug` flag description in the processing JSON schema so it actually explains what the option does (captures detailed logs visible only to super-admins) instead of restating the title.
- Split the processing sidebar into **Navigation** and **Actions** subheaders (mirroring data-fair's `dataset-actions.vue`). Navigation lists every dataset found in `config.dataset`, `config.datasets[]` or `config.datasets[].dataset`, deduplicated by id, with a "View {title}" link per dataset. It is hidden when no dataset is linked.