### PR TITLE
feat(worker): surface child memory state on failures, drop no-op --optimize-for-size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,10 @@ COPY package.json README.md LICENSE BUILD.json* ./
 EXPOSE 9090
 # USER node # This would be great to use, but not possible as the volumes are mounted as root
 WORKDIR /app/worker
-CMD ["node", "--disable-warning=ExperimentalWarning", "--optimize-for-size", "index.ts"]
+# Heavy per-run work happens in a child process spawned by the orchestrator (see worker/src/worker.ts).
+# The orchestrator itself only schedules; memory tuning should be done at the container level via
+# NODE_OPTIONS=--max-old-space-size=... and mem_limit, which propagate to both the orchestrator and the child.
+CMD ["node", "--disable-warning=ExperimentalWarning", "index.ts"]
 
 # =============================
 # Install production dependencies for API

--- a/tests/features/worker-utils/worker-operations.unit.spec.ts
+++ b/tests/features/worker-utils/worker-operations.unit.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { buildErrorMessageFromStderr } from '../../../worker/src/utils/worker-operations.ts'
+import { buildErrorMessageFromStderr, formatMemoryUsage, exitCodeHint } from '../../../worker/src/utils/worker-operations.ts'
 
 test.describe('buildErrorMessageFromStderr', () => {
   test('falls back to errMessage when stderr is empty', () => {
@@ -28,5 +28,41 @@ test.describe('buildErrorMessageFromStderr', () => {
 
   test('skips empty lines but keeps the surrounding ones', () => {
     expect(buildErrorMessageFromStderr('a\n\nb\n', 'fb')).toBe('a\nb')
+  })
+})
+
+test.describe('formatMemoryUsage', () => {
+  test('renders all components rounded to MB', () => {
+    const mb = 1024 * 1024
+    expect(formatMemoryUsage({
+      rss: 256 * mb,
+      heapUsed: 128 * mb,
+      heapTotal: 200 * mb,
+      external: 16 * mb,
+      arrayBuffers: 0
+    })).toBe('rss=256MB heap=128/200MB ext=16MB')
+  })
+
+  test('returns a string when called without arguments', () => {
+    expect(typeof formatMemoryUsage()).toBe('string')
+  })
+})
+
+test.describe('exitCodeHint', () => {
+  test('returns a V8/SIGABRT hint for code 134', () => {
+    expect(exitCodeHint(134)).toContain('SIGABRT')
+    expect(exitCodeHint(134)).toContain('NODE_OPTIONS')
+  })
+
+  test('returns an OOM-kill hint for code 137', () => {
+    expect(exitCodeHint(137)).toContain('SIGKILL')
+    expect(exitCodeHint(137)).toContain('mem_limit')
+  })
+
+  test('returns empty string for unrelated codes', () => {
+    expect(exitCodeHint(1)).toBe('')
+    expect(exitCodeHint(143)).toBe('')
+    expect(exitCodeHint(null)).toBe('')
+    expect(exitCodeHint(undefined)).toBe('')
   })
 })

--- a/worker/src/task/index.ts
+++ b/worker/src/task/index.ts
@@ -3,8 +3,13 @@ import nodemailer from 'nodemailer'
 import config from '#config'
 import mongo from '#mongo'
 import { run, stop } from './task.ts'
+import { formatMemoryUsage } from '../utils/worker-operations.ts'
 
 let exitCode = 0
+
+// Memory diagnostic: print on stderr so the parent worker captures it via
+// buildErrorMessageFromStderr when the child exits non-zero.
+console.error(`task start mem ${formatMemoryUsage()}`)
 
 process.on('SIGTERM', function onSigterm () {
   console.info('Received SIGTERM signal, shutdown gracefully...')
@@ -28,4 +33,5 @@ if (err) exitCode = 1
 await mongo.close()
 mailTransport.close()
 
+console.error(`task end mem ${formatMemoryUsage()}`)
 process.exit(exitCode)

--- a/worker/src/utils/worker-operations.ts
+++ b/worker/src/utils/worker-operations.ts
@@ -18,3 +18,24 @@ export const buildErrorMessageFromStderr = (stderr: string, errMessage: string):
   if (!lines.length) lines.push(errMessage)
   return lines.join('\n')
 }
+
+/**
+ * Format a Node.js MemoryUsage as a compact one-liner, suitable for logging.
+ * All values are rounded to MB.
+ */
+export const formatMemoryUsage = (mem: NodeJS.MemoryUsage = process.memoryUsage()): string => {
+  const mb = (n: number) => Math.round(n / 1024 / 1024)
+  return `rss=${mb(mem.rss)}MB heap=${mb(mem.heapUsed)}/${mb(mem.heapTotal)}MB ext=${mb(mem.external)}MB`
+}
+
+/**
+ * Map a non-zero child exit code to a human hint about likely causes.
+ * Returns an empty string when no specific hint applies.
+ * - 134 = SIGABRT, the signature of a V8 fatal allocation failure (std::bad_alloc / Check failed: (result.ptr) != nullptr).
+ * - 137 = SIGKILL, the signature of an OOM-kill from the host kernel / docker cgroup.
+ */
+export const exitCodeHint = (code: number | null | undefined): string => {
+  if (code === 134) return 'le processus enfant a abandonné (SIGABRT, code 134) — typique d\'une allocation V8 impossible. Vérifier NODE_OPTIONS=--max-old-space-size et la limite mémoire du conteneur.'
+  if (code === 137) return 'le processus enfant a été tué (SIGKILL, code 137) — typique d\'un OOM-kill par le noyau / cgroup docker. Augmenter mem_limit du conteneur.'
+  return ''
+}

--- a/worker/src/utils/worker-operations.ts
+++ b/worker/src/utils/worker-operations.ts
@@ -35,7 +35,7 @@ export const formatMemoryUsage = (mem: NodeJS.MemoryUsage = process.memoryUsage(
  * - 137 = SIGKILL, the signature of an OOM-kill from the host kernel / docker cgroup.
  */
 export const exitCodeHint = (code: number | null | undefined): string => {
-  if (code === 134) return 'le processus enfant a abandonné (SIGABRT, code 134) — typique d\'une allocation V8 impossible. Vérifier NODE_OPTIONS=--max-old-space-size et la limite mémoire du conteneur.'
-  if (code === 137) return 'le processus enfant a été tué (SIGKILL, code 137) — typique d\'un OOM-kill par le noyau / cgroup docker. Augmenter mem_limit du conteneur.'
+  if (code === 134) return 'le processus enfant a abandonné (SIGABRT, code 134) — typique d\'une allocation V8 impossible. Vérifier NODE_OPTIONS=--max-old-space-size et la limite mémoire du conteneur (mem_limit / resources.limits.memory).'
+  if (code === 137) return 'le processus enfant a été tué (SIGKILL, code 137) — typique d\'un OOM-kill par le noyau / cgroup. Augmenter la limite mémoire du conteneur (mem_limit / resources.limits.memory).'
   return ''
 }

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -242,10 +242,11 @@ async function iter (run: Run) {
     })
     await finish(run)
   } catch (err: any) {
-    // Build back the original error message from the stderr of the child process
-    let errorMessage = buildErrorMessageFromStderr(stderr, err.message)
+    // Build back the original error message from the stderr of the child process,
+    // appending a hint when the child exit code matches a known OOM signature.
+    const baseMessage = buildErrorMessageFromStderr(stderr, err.message)
     const hint = exitCodeHint(err.code)
-    if (hint) errorMessage = `${errorMessage}\n${hint}`
+    const errorMessage = hint ? `${baseMessage}\n${hint}` : baseMessage
 
     if (run) {
       // case of interruption by a SIGTERM

--- a/worker/src/worker.ts
+++ b/worker/src/worker.ts
@@ -18,7 +18,7 @@ import locks from '#locks'
 import limits from './utils/limits.ts'
 import { initMetrics } from './utils/metrics.ts'
 import { finish } from './utils/runs.ts'
-import { buildErrorMessageFromStderr } from './utils/worker-operations.ts'
+import { buildErrorMessageFromStderr, exitCodeHint } from './utils/worker-operations.ts'
 
 const debug = Debug('worker')
 const debugLoop = Debug('worker-loop')
@@ -243,7 +243,9 @@ async function iter (run: Run) {
     await finish(run)
   } catch (err: any) {
     // Build back the original error message from the stderr of the child process
-    const errorMessage = buildErrorMessageFromStderr(stderr, err.message)
+    let errorMessage = buildErrorMessageFromStderr(stderr, err.message)
+    const hint = exitCodeHint(err.code)
+    if (hint) errorMessage = `${errorMessage}\n${hint}`
 
     if (run) {
       // case of interruption by a SIGTERM


### PR DESCRIPTION
## Context

While investigating a recurring nightly OOM on a customer deployment, the only diagnostic that made it back to the user was:

> child process exited with code 134

That message is not actionable for an operator tuning a deployment — they can't tell whether the child hit a V8 heap ceiling, was OOM-killed by the cgroup, or died for some other reason. It took several round-trips with the customer to collect host-level `dmesg` and `docker inspect` output before the actual cause (cgroup memory limit) was confirmed.

This PR adds three small, independent diagnostic improvements to the worker so the next operator hitting the same wall gets a self-explanatory error in the run document.

## What changes

### 1. Memory snapshot on stderr at child start/end

```ts
// worker/src/task/index.ts
console.error(`task start mem ${formatMemoryUsage()}`)
// ...
console.error(`task end mem ${formatMemoryUsage()}`)
```

Renders as `rss=512MB heap=420/480MB ext=20MB`. Because the parent worker already captures the child's stderr via `buildErrorMessageFromStderr` (and filters out `worker:` debug noise), these lines are **surfaced into the run's error message on non-zero exits** — but **don't pollute successful runs** (the parent only writes an error message on a thrown exception).

> **Caveat**: `task end mem` only fires on graceful exits (including JS-level errors that return from `run()` with `exitCode = 1`). On a hard V8 crash — `std::bad_alloc` / `Check failed: (result.ptr) != nullptr`, exit 134 — or a kernel SIGKILL (exit 137), only `task start mem` survives. That's still the more useful data point: it shows the starting heap, which combined with the V8 fatal stderr and the exit-code hint below is enough to diagnose and tune the limit. Peak memory remains invisible without a heap snapshot; capturing one would require an opt-in env var (left out of this PR to keep on-prem operations friction-free).

### 2. `exitCodeHint(code)` for OOM-typical exit codes

```ts
// worker/src/utils/worker-operations.ts
exitCodeHint(134) // → "SIGABRT, typique d'une allocation V8 impossible. Vérifier NODE_OPTIONS=--max-old-space-size et la limite mémoire du conteneur (mem_limit / resources.limits.memory)."
exitCodeHint(137) // → "SIGKILL, typique d'un OOM-kill par le noyau / cgroup. Augmenter la limite mémoire du conteneur (mem_limit / resources.limits.memory)."
exitCodeHint(1)   // → "" (unrelated)
```

Appended to the run error message in `worker.ts:iter`. Existing user-facing messages in this file are already in French (`'le traitement a été désactivé'`, `'le temps de traitement autorisé est épuisé'`), so the new hint matches the convention. Both Docker Compose (`mem_limit`) and Kubernetes (`resources.limits.memory`) terminology is included so the hint is actionable on either platform.

### 3. Drop `--optimize-for-size` from the worker Dockerfile CMD

Introduced in cbadef8 ("chore: worker runs with --optimize-for-size option", no body). The flag has **no effect on the heavy per-run work** — every processing is executed in a child process `spawn`-ed without inheriting this flag (see `worker/src/worker.ts` line ~211). The orchestrator parent only schedules and polls Mongo, so `--optimize-for-size` only slightly slows its GC for no observable benefit.

Memory tuning should be done at the container level via `NODE_OPTIONS=--max-old-space-size=...` and `mem_limit` / `resources.limits.memory`, which **do** propagate to both the parent and the spawned child. The Dockerfile now includes a comment explaining this.

## What doesn't change

- No new env vars, no new config keys, no new dependencies.
- No behavior change for happy-path runs — the new lines go to stderr (with the existing `[spawned task stderr]` prefix), so they show in worker logs but don't appear in the run document unless the run actually fails.
- The error-message filtering in `buildErrorMessageFromStderr` is unchanged.

## How to verify

```sh
# Unit tests for the new helpers
npx playwright test tests/features/worker-utils/worker-operations.unit.spec.ts

# End-to-end: simulate a heap overrun
docker run -e NODE_OPTIONS='--max-old-space-size=64' <built-image> \
  # trigger a processing that allocates > 64 MB
# The run document should now show:
#   task start mem rss=XXMB heap=.../...MB ext=...MB
#   <FATAL ERROR: ... JavaScript heap out of memory>
#   le processus enfant a abandonné (SIGABRT, code 134) — typique d'une allocation V8 impossible. Vérifier NODE_OPTIONS=--max-old-space-size et la limite mémoire du conteneur (mem_limit / resources.limits.memory).
```

## Risk

Low. The new code paths are:
- Two `console.error` calls in the child startup (executes once per run regardless of outcome).
- A pure string-concat in the parent's catch block (no mutation).
- One line removed from the Dockerfile.

The three changes are independently revertable. If the new `console.error` lines somehow break a downstream log parser, they can be reverted independently of the Dockerfile change.