### PR TITLE
feat(worker): surface memory stats in run log and fix log-level colors

### DIFF
--- a/ui/src/components/run/run-logs-list.vue
+++ b/ui/src/components/run/run-logs-list.vue
@@ -18,7 +18,7 @@
     </span>
     <span
       v-else-if="['warning', 'info', 'debug'].includes(log.type)"
-      :class="log.type === 'warning' ? 'text-info' : ''"
+      :class="logTextClass(log)"
     >
       {{ log.msg }}
     </span>
@@ -63,6 +63,12 @@ defineProps({
 const taskColor = (log: LogEntry) => {
   if (log.progress && log.progress === log.total) return 'success'
   return 'primary'
+}
+
+const logTextClass = (log: LogEntry) => {
+  if (log.type === 'warning') return 'text-warning'
+  if (log.type === 'debug') return 'text-medium-emphasis'
+  return ''
 }
 
 const formatDate = (date: string) => dayjs(date).format('lll')

--- a/worker/src/task/memory-reporter.ts
+++ b/worker/src/task/memory-reporter.ts
@@ -3,6 +3,8 @@ import { formatMem, type MemorySample, type MemorySamplePhase } from '../utils/m
 
 type DebugLog = (msg: string, extra?: string) => Promise<void>
 
+const MEMORY_LOG_LABEL = 'Task process memory stats'
+
 const buildSample = (phase: MemorySamplePhase): MemorySample => {
   const m = process.memoryUsage()
   return {
@@ -22,7 +24,7 @@ const writeStdoutSample = (sample: MemorySample): void => {
 }
 
 export type MemoryReporterHandle = {
-  stop: () => void
+  stop: () => Promise<void>
 }
 
 export const startMemoryReporter = (
@@ -30,7 +32,11 @@ export const startMemoryReporter = (
   debug: DebugLog,
   intervalMs: number
 ): MemoryReporterHandle => {
-  writeStdoutSample(buildSample('startup'))
+  const startupSample = buildSample('startup')
+  writeStdoutSample(startupSample)
+  if (processing.debug) {
+    debug(`${MEMORY_LOG_LABEL} - ${formatMem(startupSample)}`).catch(() => { /* best-effort */ })
+  }
 
   let timer: NodeJS.Timeout | null = null
   if (intervalMs > 0) {
@@ -40,7 +46,7 @@ export const startMemoryReporter = (
       if (processing.debug) {
         // Skip building the debug string when debug is off
         // (log.debug also no-ops, but avoids formatMem cost).
-        debug('memory', formatMem(sample)).catch(() => { /* best-effort */ })
+        debug(`${MEMORY_LOG_LABEL} - ${formatMem(sample)}`).catch(() => { /* best-effort */ })
       }
     }, intervalMs)
     timer.unref()
@@ -53,9 +59,14 @@ export const startMemoryReporter = (
   process.on('exit', onExit)
 
   return {
-    stop: () => {
+    stop: async () => {
       if (timer) { clearInterval(timer); timer = null }
       process.off('exit', onExit)
+      const exitSample = buildSample('exit')
+      writeStdoutSample(exitSample)
+      if (processing.debug) {
+        await debug(`${MEMORY_LOG_LABEL} - ${formatMem(exitSample)}`).catch(() => { /* best-effort */ })
+      }
     }
   }
 }

--- a/worker/src/task/task.ts
+++ b/worker/src/task/task.ts
@@ -84,7 +84,7 @@ export const run = async (mailTransport: any) => {
   log.warn = log.warning // for compatibility with old plugins
   // Start memory sampler: emits df-mem: lines on stdout for parent metrics,
   // and (when processing.debug) appends debug entries to run.log.
-  startMemoryReporter(processing, log.debug, config.worker.task.memorySampleIntervalMs)
+  const memReporter = startMemoryReporter(processing, log.debug, config.worker.task.memorySampleIntervalMs)
   if (run.status === 'running') {
     await log.step('Reprise après interruption.')
   }
@@ -196,6 +196,7 @@ export const run = async (mailTransport: any) => {
     }
     return err
   } finally {
+    await memReporter.stop()
     try {
       await tmpDir.cleanup()
     } catch (err) {


### PR DESCRIPTION
Make the per-task memory debug logs added in #90 actually useful in the
run log UI, and fix two stale color choices in the run-log component.

**Why:** the new `memory-reporter` was pushing `debug('memory', formatMem(...))`
into `run.log`, but `run-logs-list.vue` only renders `log.msg` — the
actual `rss=… heapUsed=… …` payload (stored in `extra`) was silently
dropped. There were also no startup / exit entries to anchor the
periodic samples in time.

**What changed:**
- `worker/src/task/memory-reporter.ts` — when `processing.debug`, emit a
  unified `Task process memory stats - rss=… heapTotal=… heapUsed=… …`
  debug entry at startup, on every sample interval, and at stop. Payload
  is now in `msg` (visible in the UI) rather than `extra`.
- `worker/src/task/task.ts` — capture the reporter handle and
  `await memReporter.stop()` in `finally`, so the closing entry lands
  after the final success/error log.
- `ui/src/components/run/run-logs-list.vue` — `warning` entries now use
  `text-warning` (were `text-info`), and `debug` entries use
  `text-medium-emphasis` so they're visually distinct from `info`.

**Regression risks:**
- The run-log color change applies to **every** existing `warning` /
  `debug` entry across all runs, not only the new memory lines.
- `MemoryReporterHandle.stop()` is now async; the single in-tree caller
  was updated to await it.
- The exit memory entry is pushed via `log.debug` (mongo write + ws
  emit). If mongo stalls on shutdown, the task child waits on it — same
  pattern as the existing final success/error log.
