### PR TITLE
feat(ui): stick-to-bottom autoscroll on the run page

### DIFF
--- a/ui/src/composables/use-follow-bottom.ts
+++ b/ui/src/composables/use-follow-bottom.ts
@@ -1,0 +1,39 @@
+import { useScroll, useEventListener } from '@vueuse/core'
+
+/**
+ * Stick-to-bottom autoscroll for a live run log: follows new entries while the
+ * user is at the bottom, any upward scroll or wheel-up stops it, scrolling back
+ * to the bottom resumes.
+ *
+ * Targets the current document — what actually scrolls both standalone and
+ * inside data-fair's fixed-height d-frame iframe (never window.top). VueUse's
+ * `arrivedState.bottom` carries a built-in 1px tolerance, and appending a log
+ * fires no scroll event, so following only ever turns off on a real upward
+ * scroll — no manual threshold needed.
+ *
+ * @param logCount reactive getter for the log length (the growth signal)
+ * @param isActive getter telling whether the run is still streaming
+ */
+export const useFollowBottom = (logCount: () => number, isActive: () => boolean) => {
+  // Start following so a freshly opened, still-running run pins to its tail even
+  // though the page loads scrolled to the top.
+  const following = ref(true)
+
+  const { arrivedState, directions, y } = useScroll(window, {
+    onScroll: () => {
+      if (directions.top) following.value = false // scrolled up → stop
+      else if (arrivedState.bottom) following.value = true // back at bottom → resume
+    }
+  })
+
+  // A wheel-up reaches us even when the page can't scroll (short page, or
+  // data-fair's auto-height embed where the parent scrolls) — the only
+  // "stop following" signal available there.
+  useEventListener(window, 'wheel', (e: WheelEvent) => { if (e.deltaY < 0) following.value = false }, { passive: true })
+
+  const pinToBottom = () => { y.value = (document.scrollingElement ?? document.documentElement).scrollHeight }
+
+  watch(logCount, () => { if (isActive() && following.value) pinToBottom() }, { flush: 'post' })
+
+  return { following }
+}

--- a/ui/src/pages/processings/[id]/runs/[runId].vue
+++ b/ui/src/pages/processings/[id]/runs/[runId].vue
@@ -21,7 +21,7 @@
         />
         <v-expansion-panels
           v-else
-          :model-value="[steps.length - 1]"
+          v-model="openPanels"
           variant="accordion"
           multiple
           static
@@ -61,6 +61,7 @@
 
 <script setup lang="ts">
 import type { Run } from '#api/types'
+import { useFollowBottom } from '~/composables/use-follow-bottom'
 
 const { t } = useI18n()
 const route = useRoute<'/processings/[id]/runs/[runId]'>()
@@ -97,6 +98,20 @@ const steps = computed(() => {
   }
   return steps
 })
+
+const { following } = useFollowBottom(
+  () => run.value?.log.length ?? 0,
+  () => run.value?.status === 'running'
+)
+
+// While following the tail keep only the latest step open; otherwise preserve the
+// user's selection. Recomputed only when the step count changes, not on every log.
+const openPanels = ref<number[]>([])
+watch(() => steps.value.length, (stepCount) => {
+  if (stepCount <= 0) openPanels.value = []
+  else if (following.value) openPanels.value = [stepCount - 1]
+  else openPanels.value = openPanels.value.filter((i) => i < stepCount)
+}, { immediate: true })
 
 function getColor (step: Record<string, any>) {
   let color = 'success'


### PR DESCRIPTION
Add stick-to-bottom autoscroll to the run page log view: while the user is at the
bottom of a running run, the view follows new log lines as they stream in; any
upward scroll (or wheel-up) stops following, and scrolling back to the bottom
resumes it.

**What changed**
- New `ui/src/composables/use-follow-bottom.ts` — `useFollowBottom(logCount, isActive)`
  pins the document to the bottom on each new log while following and the run is
  still streaming. Uses VueUse `useScroll` (1px bottom tolerance, no manual
  threshold) plus a `wheel` listener to catch wheel-up when the page itself can't
  scroll.
- `runs/[runId].vue`: replaces the one-way `:model-value="[steps.length - 1]"`
  expansion-panel binding with a `v-model="openPanels"` recomputed by a watch on
  the step *count* (latest panel only while following, otherwise the user's
  selection minus removed steps), so panels no longer slam shut on every streamed
  log and manual toggles persist.

**Why:** the run log view didn't follow the live tail, and the previous panel
binding recomputed on every log line, collapsing panels mid-read.

**Regression risks:**
- Panel open/close semantics changed. Previously the last panel was force-opened
  on every render; now state is recomputed only when the step *count* changes.
  While following, non-latest panels collapse on each new step; when not
  following, user toggles persist. Confirm this is the intended UX.
- The page carries `data-iframe-height` (auto-height d-frame embed). `pinToBottom`
  sets the inner `window` scroll position, which is a no-op when the *parent*
  frame scrolls — so tail-following may not visually work inside an auto-height
  embed (the wheel-up "stop following" still works). Confirm whether the run page
  is embedded in that mode and whether following is expected to work there.
- `following` initializes to `true` even for completed runs; benign because
  pinning is gated by `isActive()` and the initial panel state (last open)
  matches prior behavior.
