### PR TITLE
chore: bump dev data-fair image to v6, always-serve SPA

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -35,20 +35,14 @@ if (process.env.NODE_ENV === 'development') {
   app.use('/api/v1/test-env', (await import('./misc/routers/test-env.ts')).default)
 }
 
-if (process.env.NODE_ENV !== 'development') {
-  // in development the UI is served by the Vite dev server through nginx
-  const cspDirectives = { ...defaultNonceCSPDirectives }
-  // necessary to use vjsf without pre-compilation
-  cspDirectives['script-src'] = "'unsafe-eval' " + defaultNonceCSPDirectives['script-src']
-  // necessary for vjsf to fetch remote services
-  cspDirectives['connect-src'] = "'self' https:"
-  app.use(await createSpaMiddleware(resolve(import.meta.dirname, '../../ui/dist'), uiConfig, {
-    csp: {
-      nonce: true,
-      header: cspDirectives
-    },
-    privateDirectoryUrl: config.privateDirectoryUrl
-  }))
-}
+const cspDirectives = { ...defaultNonceCSPDirectives }
+// necessary to use vjsf without pre-compilation
+cspDirectives['script-src'] = "'unsafe-eval' " + defaultNonceCSPDirectives['script-src']
+// necessary for vjsf to fetch remote services
+cspDirectives['connect-src'] = "'self' https:"
+app.use(await createSpaMiddleware(resolve(import.meta.dirname, '../../ui/dist'), uiConfig, {
+  csp: { nonce: true, header: cspDirectives },
+  privateDirectoryUrl: config.privateDirectoryUrl
+}))
 
 app.use(errorHandler)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
   data-fair:
     profiles:
       - dev
-    image: ghcr.io/data-fair/data-fair:5
+    image: ghcr.io/data-fair/data-fair:6
     restart: on-failure:10
     network_mode: host
     depends_on:


### PR DESCRIPTION
Two small dev/test infra changes, grouped together.

**What changed**
- `docker-compose.yml`: dev `data-fair` image `5 → 6` (aligns the dev upstream with the v6 registry integration already on master).
- `api/src/app.ts`: the SPA middleware now mounts in **all** environments (the `NODE_ENV !== 'development'` guard was removed). Beyond serving `ui/dist`, this middleware also serves the runtime **ui-config** that the SPA fetches at startup — so it is required even in dev, where Vite (through nginx) serves the UI assets but not that config.

**Why**
Run the dev stack against data-fair v6; serve the runtime ui-config from the API in dev too (Vite serving the UI assets isn't enough).

**Regression risks**
- `api/src/app.ts`: the SPA middleware (incl. the vjsf CSP directives and the static `ui/dist` fallback) now also mounts in dev. UI routes are still handled by Vite/nginx ahead of the API, so the static fallback is effectively inert in dev; the meaningful effect is that the ui-config is now served. Worth a sanity check that the dev request flow is otherwise unchanged.
- `data-fair:6` is a major bump of the dev upstream (dev/test only); registry/plugin integration assumptions may differ from v5.

_Two changes from earlier revisions of this branch were dropped: the `package-lock.json` churn (no `package.json` change → broke `npm ci`), and persisting registry tarballs to a `./data/registry` host bind mount (Docker created `./data` as root, breaking the dev API's `data/development` mkdir and failing the api tests; the registry runs as uid 1000, so a host bind mount can't be written without an init/chown step)._
