### PR TITLE
fix(plugins): reload updated plugins via version-keyed cache paths

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@data-fair/lib-express": "^1.22.5",
     "@data-fair/lib-node": "^2.12.1",
-    "@data-fair/lib-node-registry": "^0.6.0",
+    "@data-fair/lib-node-registry": "^0.7.0",
     "@data-fair/lib-utils": "^1.10.1",
     "@data-fair/processings-shared": "*",
     "ajv": "^8.17.1",

--- a/api/src/processings/router.ts
+++ b/api/src/processings/router.ts
@@ -184,7 +184,7 @@ const prepareProcessing = async (processing: Processing) => {
   // state is what the UI banner already shows for deleted plugins.
   if (!processing.config) return
   const { ensured } = await ensurePluginAndReadSchema(processing)
-  const plugin = await importPluginModule<{ prepare?: PrepareFunction }>(ensured.path, { cacheBust: true })
+  const plugin = await importPluginModule<{ prepare?: PrepareFunction }>(ensured.path)
   if (!(plugin.prepare && typeof plugin.prepare === 'function')) return
 
   // Decipher the actuals secrets if they are present

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "dependencies": {
         "@data-fair/lib-express": "^1.22.5",
         "@data-fair/lib-node": "^2.12.1",
-        "@data-fair/lib-node-registry": "^0.6.0",
+        "@data-fair/lib-node-registry": "^0.7.0",
         "@data-fair/lib-utils": "^1.10.1",
         "@data-fair/processings-shared": "*",
         "ajv": "^8.17.1",
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@data-fair/lib-node-registry": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@data-fair/lib-node-registry/-/lib-node-registry-0.6.0.tgz",
-      "integrity": "sha512-TT3IFJwOwksl6rGi1JIz7tBM0M3NWyDcHR3orsAtF2UGn64cvQti829lfuhTAmGOhWA/nWjWL4kxDYliOKsJNA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@data-fair/lib-node-registry/-/lib-node-registry-0.7.0.tgz",
+      "integrity": "sha512-BZiIsyBkYOuNkSqkhHJ/E4hQrRkfDwR4W7Q4b33ezRo2MTk9MMni8h8VtBPXI+Ex3A1V504n72KJHaTdNwDoew==",
       "license": "MIT",
       "dependencies": {
         "@types/resolve-path": "^1.4.3",
@@ -12221,7 +12221,7 @@
     "worker": {
       "dependencies": {
         "@data-fair/lib-node": "^2.12.1",
-        "@data-fair/lib-node-registry": "^0.6.0",
+        "@data-fair/lib-node-registry": "^0.7.0",
         "@data-fair/processings-shared": "*",
         "@mdi/js": "^7.4.47",
         "axios": "^1.8.3",

--- a/shared/plugin-load.ts
+++ b/shared/plugin-load.ts
@@ -8,13 +8,12 @@ import fs from 'fs-extra'
  * type-stripping (main: "index.ts"). Either way, callers should not hard-code
  * an extension — read main and trust it.
  *
- * `cacheBust` appends a query string so the same module path can be re-imported
- * fresh in the same process (used by the API's `prepare` flow, which may run
- * twice in one save).
+ * No cache-busting is needed: lib-node-registry (>=0.7.0) extracts each plugin
+ * version into its own directory, so an updated plugin resolves to a fresh URL
+ * and Node's module registry reloads the whole graph naturally.
  */
 export const importPluginModule = async <T = unknown>(
-  pluginDir: string,
-  opts: { cacheBust?: boolean } = {}
+  pluginDir: string
 ): Promise<T> => {
   const pkg = await fs.readJson(path.join(pluginDir, 'package.json'))
   const mainRel = typeof pkg.main === 'string' && pkg.main.length > 0 ? pkg.main : 'index.js'
@@ -22,6 +21,5 @@ export const importPluginModule = async <T = unknown>(
   if (!(await fs.pathExists(mainAbs))) {
     throw new Error(`fichier source manquant : ${mainAbs}`)
   }
-  const url = opts.cacheBust ? `${mainAbs}?imported=${Date.now()}` : mainAbs
-  return (await import(url)) as T
+  return (await import(mainAbs)) as T
 }

--- a/worker/package.json
+++ b/worker/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@data-fair/lib-node": "^2.12.1",
-    "@data-fair/lib-node-registry": "^0.6.0",
+    "@data-fair/lib-node-registry": "^0.7.0",
     "@data-fair/processings-shared": "*",
     "@mdi/js": "^7.4.47",
     "axios": "^1.8.3",


### PR DESCRIPTION
Upgrade `@data-fair/lib-node-registry` to `^0.7.0` and remove the query-string cache-busting from `importPluginModule`.

**Why:** 0.7.0 extracts each plugin version into its own directory, so an updated plugin resolves to a fresh module URL and Node's registry reloads the whole graph naturally — the manual `?imported=<timestamp>` cache-bust in the API's `prepare` flow is no longer needed.

**Regression risks:**
- Correctness now depends on 0.7.0 giving each plugin version a distinct directory. A plugin re-published with changed code under the *same* version string would resolve to the same path and be served stale from the long-lived API process (the old cache-bust would have dodged this).
- The API `prepare` flow can run twice in one save (`api/src/processings/router.ts:187`); the second import now hits Node's module cache. Safe as long as the path is identical across both runs within a save, which it should be.
- Worker is unaffected — it never used cache-busting and runs each task in a fresh child process.
