### PR TITLE
fix(ui): hide empty scheduling list for read-only users

### DIFF
--- a/ui/src/pages/processings/[id]/index.vue
+++ b/ui/src/pages/processings/[id]/index.vue
@@ -251,6 +251,7 @@ const processingSchema = computed(() => {
     delete schema.properties.permissions
     delete schema.properties.config
     delete schema.required
+    if (!processing.value.scheduling?.length) delete schema.properties.scheduling
   } else {
     schema.required = ['title', 'scheduling', 'config', 'permissions']
     schema.properties.config.required = schema.properties.config.required?.filter((s: any) => s !== 'datasetMode')


### PR DESCRIPTION
For read-only users (no admin rights on the processing), the scheduling section showed an empty, useless list header when the processing had no scheduling configured.

**Why:** the empty scheduling list looked broken/awkward for users who can only read and have nothing scheduled.

**What changed:** in the non-admin schema branch, drop `schema.properties.scheduling` when `processing.scheduling` is empty, so the section is hidden entirely. Read-only users who *do* have scheduling still see it (read-only); admin users are unaffected.

**Regression risks:**
- Only the read-only (`!canAdminProcessing`) branch is touched; the admin branch is unchanged.
- `processing.value` is guaranteed defined here (the computed returns early at the top if it isn't), so the new `?.length` access can't throw.
