### PR TITLE
chore(worker): drop x-processing header and always use private data-fair url

### DIFF
--- a/worker/config/custom-environment-variables.mjs
+++ b/worker/config/custom-environment-variables.mjs
@@ -8,7 +8,6 @@ export default {
   defaultLimits: {
     processingsSeconds: 'DEFAULT_LIMITS_PROCESSINGS_SECONDS'
   },
-  getFromPrivateDataFairUrl: 'GET_FROM_PRIVATE_DATA_FAIR_URL',
   mails: {
     transport: {
       __name: 'MAILS_TRANSPORT',

--- a/worker/config/default.mjs
+++ b/worker/config/default.mjs
@@ -30,7 +30,6 @@ export default {
     processingsSeconds: -1
   },
   privateDataFairUrl: null,
-  getFromPrivateDataFairUrl: false,
   mails: {
     // transport is a full configuration object for createTransport of nodemailer
     // cf https://nodemailer.com/smtp/

--- a/worker/config/type/schema.json
+++ b/worker/config/type/schema.json
@@ -57,9 +57,6 @@
         }
       }
     },
-    "getFromPrivateDataFairUrl": {
-      "type": "boolean"
-    },
     "mails": {
       "type": "object",
       "properties": {

--- a/worker/src/task/axios.ts
+++ b/worker/src/task/axios.ts
@@ -26,7 +26,6 @@ export const getAxiosInstance = (processing: Processing, log: LogFunctions) => {
     if (account.departmentName) account.departmentName = encodeURIComponent(account.departmentName)
     privateHeaders['x-account'] = JSON.stringify(account)
   }
-  privateHeaders['x-processing'] = JSON.stringify({ _id: processing._id, title: encodeURIComponent(processing.title) })
 
   const axiosInstance = axios.create({
     // this is necessary to prevent excessive memory usage during large file uploads, see https://github.com/axios/axios/issues/1045
@@ -45,15 +44,9 @@ export const getAxiosInstance = (processing: Processing, log: LogFunctions) => {
     const isDataFairUrl = cfg.url.startsWith(config.dataFairUrl)
     if (isDataFairUrl) Object.assign(cfg.headers, privateHeaders)
 
-    // use private data fair url if specified to prevent leaving internal infrastructure
-    // except from GET requests so that they still appear in metrics
-    // except if config.getFromPrivateDataFairUrl is set to true, then all requests are sent to the private url
-    const usePrivate =
-      config.privateDataFairUrl &&
-      isDataFairUrl &&
-      (config.getFromPrivateDataFairUrl || ['post', 'put', 'delete', 'patch'].includes(cfg.method || ''))
-    if (usePrivate) {
-      cfg.url = cfg.url.replace(config.dataFairUrl, config.privateDataFairUrl!)
+    // always route data-fair requests through the private url to stay within internal infrastructure
+    if (isDataFairUrl && config.privateDataFairUrl) {
+      cfg.url = cfg.url.replace(config.dataFairUrl, config.privateDataFairUrl)
       cfg.headers.host = new URL(config.dataFairUrl).host
     }
     return cfg


### PR DESCRIPTION
Simplify how the worker communicates with data-fair.

- Remove the `x-processing` private header previously attached to every data-fair request.
- Remove the `getFromPrivateDataFairUrl` config flag (env `GET_FROM_PRIVATE_DATA_FAIR_URL`) and its schema entry.
- Route **all** data-fair requests through `privateDataFairUrl` when it is configured, instead of only write requests (POST/PUT/DELETE/PATCH).

**Why:** keep all data-fair traffic within internal infrastructure rather than letting read requests leave via the public URL.

**Heads-up:**
- Behavior change: GET requests now go through the private URL too. The old code intentionally kept GETs on the public URL so they appeared in metrics — that read-traffic signal goes away when a private URL is set.
- The `GET_FROM_PRIVATE_DATA_FAIR_URL` env var no longer exists; remove it from any deployment config that still sets it.
