### PR TITLE
fix(ui): scope processings notifications by department

### DIFF
--- a/ui/src/components/processings-actions.vue
+++ b/ui/src/components/processings-actions.vue
@@ -104,6 +104,7 @@ import '@data-fair/frame/lib/d-frame.js'
 
 const { t } = useI18n()
 const router = useRouter()
+const session = useSessionAuthenticated()
 const processingsProps = defineProps<{
   adminMode: boolean,
   canAdmin: boolean,
@@ -151,8 +152,15 @@ const eventsSubscribeUrl = computed(() => {
     { key: 'processings:processing-log-error', title: t('topicLogError') },
     { key: 'processings:processing-disabled', title: t('topicDisabled') }
   ]
+  // Department-scoped accounts only subscribe to their own department, while
+  // root org accounts use the :* wildcard to receive events from every
+  // department of the org (root + departments), avoiding cross-department leakage.
+  const { type, id, department } = session.state.account
+  let sender = `${type}:${id}`
+  if (department) sender += ':' + department
+  else if (type === 'organization') sender += ':*'
   const urlTemplate = window.parent.location.origin + '/data-fair/processings/{processingId}'
-  return `/events/embed/subscribe?key=${encodeURIComponent(topics.map(t => t.key).join(','))}&title=${encodeURIComponent(topics.map(t => t.title).join(','))}&url-template=${encodeURIComponent(urlTemplate)}&register=false`
+  return `/events/embed/subscribe?key=${encodeURIComponent(topics.map(t => t.key).join(','))}&title=${encodeURIComponent(topics.map(t => t.title).join(','))}&url-template=${encodeURIComponent(urlTemplate)}&register=false&sender=${encodeURIComponent(topics.map(() => sender).join(','))}`
 })
 
 const statusesItems = computed(() => {


### PR DESCRIPTION
The processings-list notification subscription (`processings-actions.vue`) passed no `sender`, so it matched no events — every processings event is published with a `sender` (`run.owner`/`processing.owner`). It now builds a sender scoped to the current account:

- root org account → `organization:id:*` to receive events from every department of the org (root + departments)
- department-scoped account → `organization:id:department`, avoiding cross-department leakage
- personal account → `user:id` (no wildcard)

The sender is repeated per topic since `events`' `embed/subscribe.vue` maps `senders[i]` to topic `i`.

**Why:** mirror the reuse-submit notification fix made in data-fair/portals, following the `:*` wildcard support added in the events service (work item 61). The per-processing subscription (`processing-actions.vue`) already carries the owner's concrete department and is unchanged.

**Heads-up:** behavior change — the list previously received no notifications and now does. The `:*` wildcard relies on the events service support being deployed.
